### PR TITLE
Drop v8 support

### DIFF
--- a/.github/assert_run_in_salome.py
+++ b/.github/assert_run_in_salome.py
@@ -12,7 +12,6 @@
 import os, sys
 
 # plugin imports
-print(os.getcwd())
 sys.path.append(os.pardir) # required to be able to do "from plugin import xxx"
 from plugin.utilities.utils import IsExecutedInSalome
 

--- a/.github/assert_run_in_salome.py
+++ b/.github/assert_run_in_salome.py
@@ -12,6 +12,7 @@
 import os, sys
 
 # plugin imports
+print(os.getcwd())
 sys.path.append(os.pardir) # required to be able to do "from plugin import xxx"
 from plugin.utilities.utils import IsExecutedInSalome
 

--- a/.github/assert_run_in_salome.py
+++ b/.github/assert_run_in_salome.py
@@ -11,13 +11,17 @@
 # Check to make sure the detection for if a script is run inside salome or not is working
 import os, sys
 
+# plugin imports
+sys.path.append(os.pardir) # required to be able to do "from plugin import xxx"
+from plugin.utilities.utils import IsExecutedInSalome
+
 if len(sys.argv) == 2:
     salome_execution = bool(int(sys.argv[1]))
 else:
     raise Exception("Input whether or not this scipt is executed in Salome has to be given!")
 
 # detect wheter or not the script is run inside of Salome
-run_in_salome = ("SALOMEPATH" in os.environ)
+run_in_salome = IsExecutedInSalome()
 
 print("This script is executed in Salome:", salome_execution)
 print("Detection for running in Salome returned:",   run_in_salome)

--- a/.github/docker_ubuntu_bionic/DockerFile
+++ b/.github/docker_ubuntu_bionic/DockerFile
@@ -7,31 +7,17 @@ ARG salome_download_path
 RUN apt-get update -y && apt-get -y install --no-install-recommends \
     # software-properties-common is required for wget
     software-properties-common wget \
-    # libxml2 is required for Salome 8.4 & 8.5 (install before python2) => https://stackoverflow.com/questions/20399331/error-importing-hashlib-with-python-2-7-but-not-with-2-6#comment97786717_20419131
-    libssl1.0-dev \
-    # python 2 is required to execute Salome < 9 (dev bcs 8.3 needs it)
-    python-dev \
     # if python 3 is not explicitly installed, then autoremove will remove it
     python3 \
-    # libxml2, libfreeimage and libfreetype6 is required for Salome 8.3
-    libxml2 \
-    libfreeimage-dev \
-    libfreetype6-dev \
     # net-tools is required for Salome 9.x
     net-tools \
     # libgfortran
-    libgfortran3 \
     libgfortran4 \
     # needed by the GEOM module (see https://github.com/tianyikillua/code_aster_on_docker/issues/4)
     libglu1-mesa libxmu6 \
     # install libpng16
     libpng16-16 && \
     rm -rf /var/lib/apt/lists/* && \
-    # get & install libpng12
-    wget https://launchpad.net/~ubuntu-security/+archive/ubuntu/ppa/+build/15108504/+files/libpng12-0_1.2.54-1ubuntu1.1_amd64.deb -O $HOME/libpng12.deb && \
-    apt install $HOME/libpng12.deb && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm $HOME/libpng12.deb && \
     # getting salome
     wget -nv ${salome_download_path} -O salome_dir.tar.gz && \
     tar xzf salome_dir.tar.gz && \

--- a/.github/workflows/check_salome_execution.yml
+++ b/.github/workflows/check_salome_execution.yml
@@ -29,7 +29,9 @@ jobs:
         python-version: 3.6 # same as used in Salome 9
 
     - name: assert run not in salome
-      run: python .github/assert_run_in_salome.py 0
+      run:  |
+        cd .github
+        python .github/assert_run_in_salome.py 0
 
 
   check-salome-execution-detection:
@@ -50,4 +52,6 @@ jobs:
     - name: assert run in salome
       # given as string bcs some keywords are also recognized by yaml
       # "--shutdown-servers=1" is not used bcs container is shut down right after
-      run: "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"
+      run:  |
+        cd .github
+        "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"

--- a/.github/workflows/check_salome_execution.yml
+++ b/.github/workflows/check_salome_execution.yml
@@ -31,7 +31,7 @@ jobs:
     - name: assert run not in salome
       run:  |
         cd .github
-        python .github/assert_run_in_salome.py 0
+        python assert_run_in_salome.py 0
 
 
   check-salome-execution-detection:
@@ -52,6 +52,4 @@ jobs:
     - name: assert run in salome
       # given as string bcs some keywords are also recognized by yaml
       # "--shutdown-servers=1" is not used bcs container is shut down right after
-      run:  |
-        cd .github
-        "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"
+      run: "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"

--- a/.github/workflows/check_salome_execution.yml
+++ b/.github/workflows/check_salome_execution.yml
@@ -19,15 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [2.7, 3.6] # these versions match the ones used in salome
 
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.6 # same as used in Salome 9
 
     - name: assert run not in salome
       run: python .github/assert_run_in_salome.py 0
@@ -38,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        salome-version: [8-3, 8-4, 8-5, 9-2, 9-3, 9-4]
+        salome-version: [9-3, 9-4]
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Running tests in salome version ${{ matrix.salome-version }}
+      # "--shutdown-servers=1" is not used bcs container is shut down right after
       run: |
         cd tests
-        python3 execute_in_salome.py /root/salome_dir/salome run_all_tests.py
+        /root/salome_dir/salome -t run_all_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
       # "--shutdown-servers=1" is not used bcs container is shut down right after
       run: |
         cd tests
-        /root/salome_dir/salome -t run_all_tests.py
+        python3 execute_in_salome.py /root/salome_dir/salome run_all_tests.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [2.7, 3.6] # these versions match the ones used in salome
 
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.6 # same as used in Salome 9
 
     - name: Running tests
       run: |
@@ -39,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        salome-version: [8-3, 8-4, 8-5, 9-2, 9-3, 9-4]
+        salome-version: [9-3, 9-4]
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -71,7 +71,7 @@ jobs:
       # "--shutdown-servers=1" is not used bcs container is shut down right after
       run: |
         cd tests
-        /root/salome_dir/salome -t run_all_tests.py
+        python3 execute_in_salome.py /root/salome_dir/salome run_all_tests.py
 
 
   check-salome-execution-detection:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -71,7 +71,7 @@ jobs:
       # "--shutdown-servers=1" is not used bcs container is shut down right after
       run: |
         cd tests
-        python3 execute_in_salome.py /root/salome_dir/salome run_all_tests.py
+        /root/salome_dir/salome -t run_all_tests.py
 
 
   check-salome-execution-detection:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -76,8 +76,6 @@ jobs:
 
   check-salome-execution-detection:
     # TODO this should also check if the version-fct returns correct results
-    # TODO refactor the assert_... script to use the new fct
-    # TODO update then also the other workflow
     needs: create-docker-ubuntu
     timeout-minutes: 5
     strategy:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        salome-version: [8-3, 8-4, 8-5, 9-2, 9-3, 9-4]
+        salome-version: [9-3, 9-4]
 
     runs-on: ubuntu-18.04
 
@@ -24,15 +24,7 @@ jobs:
 
     - name: Build the Docker image for salome version ${{ matrix.salome-version }}
       run: |
-        if [ ${{ matrix.salome-version }} == 8-3 ]; then
-          SALOME_DOWNLOAD_PATH="https://www.salome-platform.org/downloads/previous-versions/salome-v8.3.0/DownloadDistr?platform=UB16.04&version=8.3.0"
-        elif [ ${{ matrix.salome-version }} == 8-4 ]; then
-          SALOME_DOWNLOAD_PATH="https://www.salome-platform.org/downloads/previous-versions/salome-v8.4.0/DownloadDistr?platform=OS1.UB16.04&version=8.4.0"
-        elif [ ${{ matrix.salome-version }} == 8-5 ]; then
-          SALOME_DOWNLOAD_PATH="https://www.salome-platform.org/downloads/previous-versions/salome-v8.5.0/DownloadDistr?platform=OS1.UB16.04&version=8.5.0"
-        elif [ ${{ matrix.salome-version }} == 9-2 ]; then
-          SALOME_DOWNLOAD_PATH="https://www.salome-platform.org/downloads/previous-versions/salome-v9.2/DownloadDistr?platform=OS1.UB18.04&version=9.2.1"
-        elif [ ${{ matrix.salome-version }} == 9-3 ]; then
+        if [ ${{ matrix.salome-version }} == 9-3 ]; then
           SALOME_DOWNLOAD_PATH="https://www.salome-platform.org/downloads/previous-versions/salome-v9.3/DownloadDistr?platform=OS1.UB18.04&version=9.3.0"
         elif [ ${{ matrix.salome-version }} == 9-4 ]; then
           SALOME_DOWNLOAD_PATH="https://www.salome-platform.org/downloads/current-version/DownloadDistr?platform=SP.UB18.04&version=9.4.0"
@@ -65,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        salome-version: [8-3, 8-4, 8-5, 9-2, 9-3, 9-4]
+        salome-version: [9-3, 9-4]
 
     runs-on: ubuntu-18.04
 
@@ -91,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        salome-version: [8-3, 8-4, 8-5, 9-2, 9-3, 9-4]
+        salome-version: [9-3, 9-4]
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -94,4 +94,6 @@ jobs:
     - name: assert run in salome
       # given as string bcs some keywords are also recognized by yaml
       # "--shutdown-servers=1" is not used bcs container is shut down right after
-      run: "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"
+      run: |
+        cd .github
+        "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -94,6 +94,4 @@ jobs:
     - name: assert run in salome
       # given as string bcs some keywords are also recognized by yaml
       # "--shutdown-servers=1" is not used bcs container is shut down right after
-      run: |
-        cd .github
-        "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"
+      run: "/root/salome_dir/salome -t .github/assert_run_in_salome.py args:1"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ For a more consolidated solution please check the [GiD interface](https://github
 This plugin extends the Salome GUI by using the python plugin functionalities, see the [docs](https://docs.salome-platform.org/9/gui/GUI/using_pluginsmanager.html#). It is purely python based, which means that Salome does not have to be compiled. It is sufficient to download the binaries provided by Salome and set up the plugin by following the instructions in the next section.
 The plugin works with meshes created in the *Mesh* module of Salome.
 
+**Minimum supported version**
+The oldest supported version is Salome 9.3. Check the developers readme for details.
+
 ## Setup
   - Clone the repo
 
@@ -27,7 +30,7 @@ The plugin works with meshes created in the *Mesh* module of Salome.
       Use `echo SALOME_PLUGINS_PATH="${HOME}/KratosSalomePlugin/plugin" >> ~/.bashrc` to directly add it to your `bashrc`
 
   - In Salome: Click `Tools/Plugin/Kratos Multiphysics` in order to load the plugin.\
-    Newer versions of Salome (>= 9.3) have a small icon with which the plugin can be loaded: <img src="plugin/utilities/kratos_logo.png" width="24">
+    Also a small icon with which the plugin can be loaded appears in the menu list: <img src="plugin/utilities/kratos_logo.png" width="24">
     <img src="plugin/utilities/load_plugin.png" width="400">
 
 **Troubleshooting Salome**

--- a/development/README.md
+++ b/development/README.md
@@ -20,3 +20,12 @@ This file contains a collection of links that are useful for the development
 **Testing**
 Mock objects are not used because it is not included in Salome => Mock is only part of unittest since python3.3
 "terminate called after throwing an instance of 'CORBA::OBJECT_NOT_EXIST'" called after tests in Version 9, related to study clearing but nothing to worry about
+
+**Resons to drop support for versions > 9**
+- Mock unittesting is not available
+- return value is not correct in older version, makes use of wrapper necessary
+- PointerVectorSet not working with py-2 (infinite recursion)
+- filtering on subgeom seems not to work
+- well, python2 ...
+- some other methods inside of salome are not working (e.g. GetSalomeObject from identifier, or some classes only have type "instance")
+- study management much easier, since now there is only one study and I don't have to maintain two different versions

--- a/plugin/salome_plugins.py
+++ b/plugin/salome_plugins.py
@@ -132,15 +132,21 @@ def InitializePlugin(context):
 fct_args = [
     'Kratos Multiphysics',
     'Starting the plugin for Kratos Multiphysics',
-    InitializePlugin]
+]
 
 import salome_pluginsmanager
 import utilities.salome_utilities as salome_utils
+from utilities.utils import GetAbsPathInPlugin
 
 if salome_utils.GetVersion() >= (9,3):
-    from utilities.utils import GetAbsPathInPlugin
+    fct_args.append(InitializePlugin)
     from qtsalome import QIcon
     icon_file = GetAbsPathInPlugin("utilities","kratos_logo.png")
     fct_args.append(QIcon(icon_file))
+else:
+    def ShowMessageUnSupportedVersion(dummy):
+        from qtsalome import QMessageBox
+        QMessageBox.critical(None, 'Unsupported version', 'This Plugin only works for Salome versions 9.3 and newer.')
+    fct_args.append(ShowMessageUnSupportedVersion)
 
 salome_pluginsmanager.AddFunction(*fct_args)

--- a/plugin/salome_plugins.py
+++ b/plugin/salome_plugins.py
@@ -28,7 +28,7 @@ logger_levels = { 0 : logging.WARNING,
 # configuring the root logger, same configuration will be automatically used for other loggers
 root_logger = logging.getLogger()
 root_logger.setLevel(logger_levels[logger_level])
-root_logger.handlers = [] # has to be cleared, otherwise more and more handlers are added if the plugin is reopened
+root_logger.handlers.clear() # has to be cleared, otherwise more and more handlers are added if the plugin is reopened
 
 # logging to console - without timestamp
 ch = logging.StreamHandler()
@@ -68,6 +68,7 @@ def InitializePlugin(context):
     from module_reload_order import MODULE_RELOAD_ORDER
     import version
     from utilities import salome_utilities
+    import qtsalome
 
     ### functions used in the plugin ###
     def ReloadModules():
@@ -119,12 +120,27 @@ def InitializePlugin(context):
 
     logger.info("Successfully initialized plugin")
 
+    # check version of py-qt
+    expected_qt_version = 5
+    if not qtsalome.QT_SALOME_VERSION == expected_qt_version:
+        logger.warning('The version of PyQt has changed, from {} to {}!'.format(expected_qt_version, QT_SALOME_VERSION))
+
+    # check if version of salome is among the checked versions
+    # TODO this should only appear once, couple it with data-handler intialization
+    if not salome_utilities.GetVersion() in version.TESTED_SALOME_VERSIONS:
+        msg  = 'This Plugin is not tested with this version of Salome.\n'
+        msg += 'The tested versions are:'
+        for v in version.TESTED_SALOME_VERSIONS:
+            msg += '\n    {}.{}'.format(v[0], v[1])
+        qtsalome.QMessageBox.warning(None, 'Untested Salome Version', msg)
+
     # message saying that it is under development
     info_msg  = 'This Plugin is currently under development and not fully operational yet.\n'
     info_msg += 'Please check "https://github.com/philbucher/KratosSalomePlugin" again at a later time.\n'
     info_msg += 'For further questions / requests please open an issue or contact "philipp.bucher@tum.de" directly.'
 
-    QMessageBox.warning(None, 'Under Development', info_msg) # for some reason works without importing "QMessageBox". not going to be investigated since temp solution
+    qtsalome.QMessageBox.warning(None, 'Under Development', info_msg)
+
 
 
 ### Registering the Plugin in Salome ###

--- a/plugin/salome_plugins.py
+++ b/plugin/salome_plugins.py
@@ -123,7 +123,7 @@ def InitializePlugin(context):
     # check version of py-qt
     expected_qt_version = 5
     if not qtsalome.QT_SALOME_VERSION == expected_qt_version:
-        logger.warning('The version of PyQt has changed, from {} to {}!'.format(expected_qt_version, QT_SALOME_VERSION))
+        logger.warning('The version of PyQt has changed, from {} to {}!'.format(expected_qt_version, qtsalome.QT_SALOME_VERSION))
 
     # check if version of salome is among the checked versions
     # TODO this should only appear once, couple it with data-handler intialization

--- a/plugin/version.py
+++ b/plugin/version.py
@@ -15,10 +15,6 @@ VERSION = (0,1) # major, minor
 
 # versions of salome with which the plugin was tested
 TESTED_SALOME_VERSIONS = [
-    (8,3),
-    (8,4),
-    (8,5),
-    (9,2),
     (9,3),
     (9,4)
 ]

--- a/tests/test_model_part.py
+++ b/tests/test_model_part.py
@@ -29,9 +29,6 @@ class TestModelPart(object):
     """
 
     def setUp(self):
-        if (sys.version_info < (3, 2)):
-            self.assertRaisesRegex = self.assertRaisesRegexp
-
         self.model_part = self._CreateModelPart()
 
     def test_SubModelParts(self):

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -57,8 +57,7 @@ class SalomeTestCase(unittest.TestCase):
         # unfortunately "salome.ObjectToID" seems not to work with salome versions < 9
         # due to this reason the expected ID has to be provided
         # in newer versions it is checked if it is the same as the actual ID of the object
-        if salome_utils.GetVersionMajor() >= 9:
-            self.assertEqual(expected_id, salome.ObjectToID(salome_object))
+        self.assertEqual(expected_id, salome.ObjectToID(salome_object))
 
         return expected_id
 

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -43,53 +43,14 @@ class SalomeTestCase(unittest.TestCase):
 
     def setUp(self):
         # initializing salome also creates a study.
-        # closing and creating a new study (salome < 9) or clearing the study (salome >= 9)
-        # in order to have a clean study for each test.
+        # clearing the study in order to have a clean study for each test.
         # This is much faster than re-launching salome for each test
-        # Note: The behavior is quite different between different versions of salome,
-        # since from version 9 salome is single study, before multiple studies were possible!
-        # This also requires different arguments for some functions
+        self.study = salome.myStudy
+        self.study.Clear()
+        salome.salome_study_init()
 
-        if salome_utils.GetVersionMajor() < 9:
-            self.__CloseOpenStudies()
-
-            salome.createNewStudy()
-
-            open_studies = salome.myStudyManager.GetOpenStudies()
-            num_open_studies = len(open_studies)
-            if num_open_studies != 1:
-                raise Exception("Wrong number of open studies: {}".format(num_open_studies))
-
-            self.study = salome.myStudyManager.GetStudyByName(open_studies[0])
-
-            self.geompy = geomBuilder.New(self.study)
-            self.smesh = smeshBuilder.New(self.study)
-
-        else:
-            self.study = salome.myStudy
-            self.study.Clear()
-            salome.salome_study_init()
-
-            self.geompy = geomBuilder.New()
-            self.smesh = smeshBuilder.New()
-
-    @classmethod
-    def tearDownClass(cls):
-        # make sure to clean leftovers, otherwise can cause errors at exit
-        if salome_utils.GetVersionMajor() < 9:
-            cls.__CloseOpenStudies()
-
-    @classmethod
-    def __CloseOpenStudies(cls):
-        if salome_utils.GetVersionMajor() >= 9:
-            raise Exception("This method can only be used with versions < 9!")
-
-        for study_id in salome.myStudyManager.GetOpenStudies():
-            salome.myStudyManager.Close(salome.myStudyManager.GetStudyByName(study_id))
-
-        num_open_studies = len(salome.myStudyManager.GetOpenStudies())
-        if num_open_studies != 0:
-            raise Exception("{} open studies still exist!".format(num_open_studies))
+        self.geompy = geomBuilder.New()
+        self.smesh = smeshBuilder.New()
 
     def GetSalomeID(self, salome_object, expected_id):
         # this function returns the ID of a given salome object, which is only useful for tests so far


### PR DESCRIPTION
Too much overhead maintaining it, has some significant drawbacks:
- Mock unittesting is not available
- return value is not correct in older version, makes use of wrapper necessary
- PointerVectorSet not working with py-2 (infinite recursion)
- filtering on subgeom seems not to work
- well, python2 ...
- some other methods inside of salome are not working (e.g. GetSalomeObject from identifier, or some classes only have type "instance")
- study management much easier, since now there is only one study and I don't have to maintain two different versions
- `__init__.py` are not needed