### PR TITLE
Impove logger

### DIFF
--- a/ks_plugin/plugin_logging.py
+++ b/ks_plugin/plugin_logging.py
@@ -19,12 +19,14 @@ from .utilities.utils import GetAbsPathInPlugin
 class _AnsiColorStreamHandler(logging.StreamHandler):
     # adapted from https://gist.github.com/mooware/a1ed40987b6cc9ab9c65
     DEFAULT = '\x1b[0m'
-    RED     = '\x1b[31m'
-    GREEN   = '\x1b[32m'
-    YELLOW  = '\x1b[33m'
-    CYAN    = '\x1b[36m'
+    RED     = '\x1b[1;31m'
+    RED_UDL = '\x1b[1;4m\x1b[1;31m'
+    GREEN   = '\x1b[1;32m'
+    YELLOW  = '\x1b[1;33m'
+    BLUE    = '\x1b[1;34m'
+    CYAN    = '\x1b[1;36m'
 
-    CRITICAL = RED
+    CRITICAL = RED_UDL
     ERROR    = RED
     WARNING  = YELLOW
     INFO     = GREEN

--- a/ks_plugin/plugin_logging.py
+++ b/ks_plugin/plugin_logging.py
@@ -39,13 +39,13 @@ def InitializeLogging(logging_level=logging.DEBUG):
 
         # logging to console - without timestamp
         ch = logging.StreamHandler()
-        ch_formatter = logging.Formatter("KSP [%(levelname)8s] %(name)s : %(message)s")
+        ch_formatter = logging.Formatter("KSP [%(levelname)-8s] %(name)s : %(message)s")
         ch.setFormatter(ch_formatter)
         root_logger.addHandler(ch)
 
         # logging to file - with timestamp
         log_file_path = os.getenv("KRATOS_SALOME_PLUGIN_LOG_FILE_PATH", GetAbsPathInPlugin(os.pardir)) # unless otherwise specified log in root-dir
         fh = RotatingFileHandler(os.path.join(log_file_path, "kratos_salome_plugin.log"), maxBytes=5*1024*1024, backupCount=1) # 5 MB
-        fh_formatter = logging.Formatter("[%(asctime)s] [%(levelname)8s] %(name)s : %(message)s", "%Y-%m-%d %H:%M:%S")
+        fh_formatter = logging.Formatter("[%(asctime)s] [%(levelname)-8s] %(name)s : %(message)s", "%Y-%m-%d %H:%M:%S")
         fh.setFormatter(fh_formatter)
         root_logger.addHandler(fh)

--- a/ks_plugin/plugin_logging.py
+++ b/ks_plugin/plugin_logging.py
@@ -16,6 +16,37 @@ from logging.handlers import RotatingFileHandler
 # plugin imports
 from .utilities.utils import GetAbsPathInPlugin
 
+class _AnsiColorStreamHandler(logging.StreamHandler):
+    DEFAULT = '\x1b[0m'
+    RED     = '\x1b[31m'
+    GREEN   = '\x1b[32m'
+    YELLOW  = '\x1b[33m'
+    CYAN    = '\x1b[36m'
+
+    CRITICAL = RED
+    ERROR    = RED
+    WARNING  = YELLOW
+    INFO     = GREEN
+    DEBUG    = CYAN
+
+    @classmethod
+    def __GetColor(cls, level):
+        if   level == logging.CRITICAL: return cls.CRITICAL
+        elif level == logging.ERROR:    return cls.ERROR
+        elif level == logging.WARNING:  return cls.WARNING
+        elif level == logging.INFO:     return cls.INFO
+        elif level == logging.DEBUG:    return cls.DEBUG
+        else:                           return cls.DEFAULT
+
+    @classmethod
+    def __ColorLevel(cls, record):
+        return cls.__GetColor(record.levelno) + record.levelname + cls.DEFAULT
+
+    def format(self, record):
+        text = super().format(record)
+        return text.replace(record.levelname, self.__ColorLevel(record))
+
+
 def InitializeLogging(logging_level=logging.DEBUG):
     # TODO switch the default in the future
     # TODO this should come from the config file
@@ -38,7 +69,7 @@ def InitializeLogging(logging_level=logging.DEBUG):
         root_logger.handlers.clear() # has to be cleared, otherwise more and more handlers are added if the plugin is reopened
 
         # logging to console - without timestamp
-        ch = logging.StreamHandler()
+        ch = _AnsiColorStreamHandler()
         ch_formatter = logging.Formatter("KSP [%(levelname)-8s] %(name)s : %(message)s")
         ch.setFormatter(ch_formatter)
         root_logger.addHandler(ch)

--- a/ks_plugin/plugin_logging.py
+++ b/ks_plugin/plugin_logging.py
@@ -17,6 +17,7 @@ from logging.handlers import RotatingFileHandler
 from .utilities.utils import GetAbsPathInPlugin
 
 class _AnsiColorStreamHandler(logging.StreamHandler):
+    # adapted from https://gist.github.com/mooware/a1ed40987b6cc9ab9c65
     DEFAULT = '\x1b[0m'
     RED     = '\x1b[31m'
     GREEN   = '\x1b[32m'
@@ -69,7 +70,17 @@ def InitializeLogging(logging_level=logging.DEBUG):
         root_logger.handlers.clear() # has to be cleared, otherwise more and more handlers are added if the plugin is reopened
 
         # logging to console - without timestamp
-        ch = _AnsiColorStreamHandler()
+        if "NO_COLOR" in os.environ:
+            # see https://no-color.org/
+            ch = logging.StreamHandler()
+        else:
+            if os.name=="nt":
+                # handler that supports color in Win is not yet implemented
+                # see https://gist.github.com/mooware/a1ed40987b6cc9ab9c65
+                ch = logging.StreamHandler()
+            else:
+                ch = _AnsiColorStreamHandler()
+
         ch_formatter = logging.Formatter("KSP [%(levelname)-8s] %(name)s : %(message)s")
         ch.setFormatter(ch_formatter)
         root_logger.addHandler(ch)

--- a/ks_plugin/plugin_logging.py
+++ b/ks_plugin/plugin_logging.py
@@ -70,7 +70,7 @@ def InitializeLogging(logging_level=logging.DEBUG):
         root_logger.handlers.clear() # has to be cleared, otherwise more and more handlers are added if the plugin is reopened
 
         # logging to console - without timestamp
-        if "NO_COLOR" in os.environ:
+        if "NO_COLOR" in os.environ: # maybe also check if isatty!
             # see https://no-color.org/
             ch = logging.StreamHandler()
         else:


### PR DESCRIPTION
Improvements:
- Now levels are left aligned
- In non-windows the levels are colored now
- [NO_COLOR](https://no-color.org/) is implemented

![image](https://user-images.githubusercontent.com/25484702/82435529-b625f680-9a94-11ea-921e-825de59b6fdb.png)

Maybe in the future:
- implement colors also in Win
- Check whether it is necessary to check for `atty` => I thought this is an issue when loading the plugin in Salome, but there the logs are not printed anyway...