### PR TITLE
[GUI] show active window after minimizing

### DIFF
--- a/kratos_salome_plugin/gui/active_window.py
+++ b/kratos_salome_plugin/gui/active_window.py
@@ -1,0 +1,1 @@
+ACTIVE_WINDOW=None

--- a/kratos_salome_plugin/gui/active_window.py
+++ b/kratos_salome_plugin/gui/active_window.py
@@ -1,1 +1,18 @@
+#  _  __         _          ___       _               ___ _           _
+# | |/ /_ _ __ _| |_ ___ __/ __| __ _| |___ _ __  ___| _ \ |_  _ __ _(_)_ _
+# | ' <| '_/ _` |  _/ _ (_-<__ \/ _` | / _ \ '  \/ -_)  _/ | || / _` | | ' \
+# |_|\_\_| \__,_|\__\___/__/___/\__,_|_\___/_|_|_\___|_| |_|\_,_\__, |_|_||_|
+#                                                               |___/
+# License: BSD License ; see LICENSE
+#
+# Main authors: Philipp Bucher (https://github.com/philbucher)
+#
+
+"""
+The currently active window is saved in a global variable
+This is necessary in case the window gets minimized
+I.e. when the plugin is reopened (with a previously minimized window)
+then the last opened window is shown again instead of creating again the base window
+"""
+
 ACTIVE_WINDOW=None

--- a/kratos_salome_plugin/gui/base_window.py
+++ b/kratos_salome_plugin/gui/base_window.py
@@ -73,6 +73,10 @@ class BaseWindow(QMainWindow):
         if self.parent:
             self.parent.show()
 
+        # resetting the global var to not accidentially keep a closed window alive
+        # this could happen if the window was minimized at some point
+        active_window.ACTIVE_WINDOW = None
+
         super().closeEvent(event)
 
     def changeEvent(self, event):

--- a/kratos_salome_plugin/gui/base_window.py
+++ b/kratos_salome_plugin/gui/base_window.py
@@ -21,13 +21,14 @@ from PyQt5.QtGui import QIcon
 from PyQt5 import uic
 
 # plugin imports
+import kratos_salome_plugin.gui.active_window as active_window
 from kratos_salome_plugin.utilities import GetAbsPathInPlugin
 from kratos_salome_plugin.utilities import PathCheck
 
 
 class BaseWindow(QMainWindow):
     def __init__(self, ui_form_path, parent=None):
-        logger.debug('Creating BaseWindow')
+        logger.debug('Creating %s', self.__name__)
 
         super().__init__()
 
@@ -78,9 +79,7 @@ class BaseWindow(QMainWindow):
         if event.type() == QEvent.WindowStateChange:
             if self.windowState() & Qt.WindowMinimized:
                 print("Minimizing!!!")
-                global ACTIVE_WINDOW
-                ACTIVE_WINDOW = self
-                print(ACTIVE_WINDOW)
+                active_window.ACTIVE_WINDOW = self
 
         super().changeEvent(event)
 

--- a/kratos_salome_plugin/gui/base_window.py
+++ b/kratos_salome_plugin/gui/base_window.py
@@ -78,7 +78,8 @@ class BaseWindow(QMainWindow):
     def changeEvent(self, event):
         if event.type() == QEvent.WindowStateChange:
             if self.windowState() & Qt.WindowMinimized:
-                print("Minimizing!!!")
+                # saving the currently active window such that it can be maximized again
+                # when the plugin is re-opened in salome
                 active_window.ACTIVE_WINDOW = self
 
         super().changeEvent(event)

--- a/kratos_salome_plugin/gui/base_window.py
+++ b/kratos_salome_plugin/gui/base_window.py
@@ -28,9 +28,9 @@ from kratos_salome_plugin.utilities import PathCheck
 
 class BaseWindow(QMainWindow):
     def __init__(self, ui_form_path, parent=None):
-        logger.debug('Creating %s', self.__name__)
-
         super().__init__()
+
+        logger.debug('Creating %s', self.__class__.__name__)
 
         PathCheck(ui_form_path)
         self.__InitUI(ui_form_path)

--- a/kratos_salome_plugin/gui/base_window.py
+++ b/kratos_salome_plugin/gui/base_window.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # qt imports
 from PyQt5.QtWidgets import QMainWindow
-from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtCore import Qt, QTimer, QEvent
 from PyQt5.QtGui import QIcon
 from PyQt5 import uic
 
@@ -38,6 +38,14 @@ class BaseWindow(QMainWindow):
         # hide parent if existing
         if self.parent:
             self.parent.hide()
+
+    def ShowOnTop(self) -> None:
+        """show and activate the window, works both if opened newly or minimized
+        see https://kb.froglogic.com/squish/qt/howto/maximizing-minimizing-restoring-resizing-positioning-windows/
+        """
+        self.show()
+        self.activateWindow()
+        self.setWindowState(Qt.WindowNoState)
 
     def StatusBarInfo(self, message: str, msg_time: int=10) -> None:
         """show an info message in the statusbar
@@ -65,6 +73,16 @@ class BaseWindow(QMainWindow):
             self.parent.show()
 
         super().closeEvent(event)
+
+    def changeEvent(self, event):
+        if event.type() == QEvent.WindowStateChange:
+            if self.windowState() & Qt.WindowMinimized:
+                print("Minimizing!!!")
+                global ACTIVE_WINDOW
+                ACTIVE_WINDOW = self
+                print(ACTIVE_WINDOW)
+
+        super().changeEvent(event)
 
     def __InitUI(self, ui_form_path) -> None:
         """initialize the user interface from the "ui" file

--- a/kratos_salome_plugin/gui/groups_window.py
+++ b/kratos_salome_plugin/gui/groups_window.py
@@ -23,7 +23,6 @@ from kratos_salome_plugin.gui.base_window import BaseWindow
 
 class GroupsWindow(BaseWindow):
     def __init__(self, parent):
-        logger.debug('Creating GroupsWindow')
         super().__init__(Path(GetAbsPathInPlugin("gui", "ui_forms", "groups_window.ui")), parent)
 
 

--- a/kratos_salome_plugin/gui/plugin_controller.py
+++ b/kratos_salome_plugin/gui/plugin_controller.py
@@ -42,17 +42,12 @@ class PluginController:
 
         self.__ConnectMainWindow()
 
-    def ShowMainWindow(self) -> None:
-        """show main window"""
-        pass
-
 
     def __InitializeMembers(self) -> None:
         """completely reinitialize members to clean them"""
         self._project_manager = ProjectManager()
         self._project_path_handler = ProjectPathHandler()
         self._previous_save_path = None
-
 
     def __ConnectMainWindow(self) -> None:
         ### File menu

--- a/kratos_salome_plugin/gui/plugin_controller.py
+++ b/kratos_salome_plugin/gui/plugin_controller.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 from kratos_salome_plugin.exceptions import UserInputError
 from kratos_salome_plugin.gui.plugin_main_window import PluginMainWindow
 from kratos_salome_plugin.gui.about import ShowAbout
+import kratos_salome_plugin.gui.active_window as active_window
 from kratos_salome_plugin.gui.project_manager import ProjectManager
 from kratos_salome_plugin.gui.project_path_handler import ProjectPathHandler
 
@@ -35,13 +36,16 @@ class PluginController:
     def __init__(self):
         logger.debug('Creating PluginController')
         self._main_window = PluginMainWindow()
+        active_window.ACTIVE_WINDOW = self._main_window
+        print(active_window.ACTIVE_WINDOW)
+
         self.__InitializeMembers()
 
         self.__ConnectMainWindow()
 
     def ShowMainWindow(self) -> None:
         """show main window"""
-        self._main_window.ShowOnTop()
+        pass
 
 
     def __InitializeMembers(self) -> None:

--- a/kratos_salome_plugin/gui/plugin_controller.py
+++ b/kratos_salome_plugin/gui/plugin_controller.py
@@ -37,7 +37,6 @@ class PluginController:
         logger.debug('Creating PluginController')
         self._main_window = PluginMainWindow()
         active_window.ACTIVE_WINDOW = self._main_window
-        print(active_window.ACTIVE_WINDOW)
 
         self.__InitializeMembers()
 

--- a/kratos_salome_plugin/gui/plugin_main_window.py
+++ b/kratos_salome_plugin/gui/plugin_main_window.py
@@ -29,14 +29,6 @@ class PluginMainWindow(BaseWindow):
         logger.debug('Creating PluginMainWindow')
         super().__init__(Path(GetAbsPathInPlugin("gui", "ui_forms", "plugin_main_window.ui")))
 
-    def ShowOnTop(self) -> None:
-        """show and activate the window, works both if opened newly or minimized
-        see https://kb.froglogic.com/squish/qt/howto/maximizing-minimizing-restoring-resizing-positioning-windows/
-        """
-        self.show()
-        self.activateWindow()
-        self.setWindowState(Qt.WindowNoState)
-
     def closeEvent(self, event):
         """prevent the window from closing, only hiding it
         Note that this deliberately does not call the baseclass, as the event should be ignored

--- a/kratos_salome_plugin/gui/plugin_main_window.py
+++ b/kratos_salome_plugin/gui/plugin_main_window.py
@@ -23,7 +23,6 @@ from kratos_salome_plugin.gui.base_window import BaseWindow
 
 class PluginMainWindow(BaseWindow):
     def __init__(self):
-        logger.debug('Creating PluginMainWindow')
         super().__init__(Path(GetAbsPathInPlugin("gui", "ui_forms", "plugin_main_window.ui")))
 
     def closeEvent(self, event):

--- a/kratos_salome_plugin/gui/plugin_main_window.py
+++ b/kratos_salome_plugin/gui/plugin_main_window.py
@@ -16,9 +16,6 @@ from pathlib import Path
 import logging
 logger = logging.getLogger(__name__)
 
-# qt imports
-from PyQt5.QtCore import Qt
-
 # plugin imports
 from kratos_salome_plugin.utilities import GetAbsPathInPlugin
 from kratos_salome_plugin.gui.base_window import BaseWindow

--- a/kratos_salome_plugin/gui/plugin_main_window.py
+++ b/kratos_salome_plugin/gui/plugin_main_window.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 # plugin imports
 from kratos_salome_plugin.utilities import GetAbsPathInPlugin
 from kratos_salome_plugin.gui.base_window import BaseWindow
+import kratos_salome_plugin.gui.active_window as active_window
 
 
 class PluginMainWindow(BaseWindow):
@@ -29,6 +30,10 @@ class PluginMainWindow(BaseWindow):
         """prevent the window from closing, only hiding it
         Note that this deliberately does not call the baseclass, as the event should be ignored
         """
+        # making this window the active one so that it can be reopened
+        # needed when reopening the plugin in salome
+        active_window.ACTIVE_WINDOW = self
+
         event.ignore()
         self.hide()
 

--- a/kratos_salome_plugin/reload_modules.py
+++ b/kratos_salome_plugin/reload_modules.py
@@ -42,6 +42,7 @@ MODULE_RELOAD_ORDER = [
     "base_application",
     "gui.utilities",
     "gui.about",
+    "gui.active_window",
     "gui.project_path_handler",
     "gui.project_manager",
     "gui.base_window",

--- a/salome_plugins.py
+++ b/salome_plugins.py
@@ -28,6 +28,7 @@ def InitializePlugin(context):
 
     # plugin imports
     from kratos_salome_plugin.gui.plugin_controller import PluginController
+    import kratos_salome_plugin.gui.active_window as active_window
     import kratos_salome_plugin.version as plugin_version
     from kratos_salome_plugin import salome_utilities
     from kratos_salome_plugin.reload_modules import ReloadModules
@@ -70,8 +71,10 @@ def InitializePlugin(context):
     if 'PLUGIN_CONTROLLER' not in globals() or reinitialize_every_time:
         # initialize only once the PluginController
         PLUGIN_CONTROLLER = PluginController()
+        print("222", active_window.ACTIVE_WINDOW)
+    print("333", active_window.ACTIVE_WINDOW)
 
-    PLUGIN_CONTROLLER.ShowMainWindow()
+    active_window.ACTIVE_WINDOW.ShowOnTop()
 
     logger.info("Successfully initialized plugin")
 

--- a/salome_plugins.py
+++ b/salome_plugins.py
@@ -71,8 +71,6 @@ def InitializePlugin(context):
     if 'PLUGIN_CONTROLLER' not in globals() or reinitialize_every_time:
         # initialize only once the PluginController
         PLUGIN_CONTROLLER = PluginController()
-        print("222", active_window.ACTIVE_WINDOW)
-    print("333", active_window.ACTIVE_WINDOW)
 
     active_window.ACTIVE_WINDOW.ShowOnTop()
 

--- a/tests/test_base_window.py
+++ b/tests/test_base_window.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 # plugin imports
 from kratos_salome_plugin.gui.base_window import BaseWindow
+import kratos_salome_plugin.gui.active_window as active_window
 
 # tests imports
 from testing_utilities import QtTestCase, GetTestsPath
@@ -119,6 +120,30 @@ class TestBaseWindowHideParent(QtTestCase):
 
         window.close()
         self.assertTrue(parent_window.isVisible())
+
+
+class TestBaseWindowMinimize_ActiveWindow(QtTestCase):
+    def setUp(self):
+        # setting initial state
+        active_window.ACTIVE_WINDOW = None
+
+    def test_set_active_window(self):
+        window = BaseWindow(ui_file)
+        window.show()
+
+        window.setWindowState(Qt.WindowMinimized)
+
+        self.assertIs(active_window.ACTIVE_WINDOW, window)
+
+    def test_set_active_window_parent(self):
+        parent_window = BaseWindow(ui_file)
+        parent_window.show()
+
+        window = BaseWindow(ui_file, parent_window)
+
+        window.setWindowState(Qt.WindowMinimized)
+
+        self.assertIs(active_window.ACTIVE_WINDOW, window)
 
 
 if __name__ == '__main__':

--- a/tests/test_base_window.py
+++ b/tests/test_base_window.py
@@ -145,6 +145,19 @@ class TestBaseWindowMinimize_ActiveWindow(QtTestCase):
 
         self.assertIs(active_window.ACTIVE_WINDOW, window)
 
+    def test_set_active_window_reset(self):
+        parent_window = BaseWindow(ui_file)
+        parent_window.show()
+
+        window = BaseWindow(ui_file, parent_window)
+
+        window.setWindowState(Qt.WindowMinimized)
+
+        window.show()
+        window.close()
+
+        self.assertIsNone(active_window.ACTIVE_WINDOW) # make sure resettign the global var works
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_base_window.py
+++ b/tests/test_base_window.py
@@ -59,6 +59,33 @@ class TestBaseWindowShortcuts(QtTestCase):
             self.assertEqual(path_close_event.call_count, 1)
 
 
+class TestBaseWindowWindowStates(QtTestCase):
+    """This test makes sure the window shows up again after being minimized"""
+    def test_minimize(self):
+        window = BaseWindow()
+        self.assertTrue(window.isHidden())
+
+        window.ShowOnTop()
+
+        window.setWindowState(Qt.WindowMinimized)
+
+        self.assertFalse(window.isActiveWindow())
+        self.assertTrue(window.isMinimized())
+        self.assertTrue(window.isVisible())
+        self.assertFalse(window.isHidden())
+        self.assertEqual(window.windowState(), Qt.WindowMinimized)
+
+        window.ShowOnTop()
+
+        # self.assertTrue(window.isActiveWindow()) # commented as doesn't work in the CI and in Linux, seems OS dependent
+        self.assertFalse(window.isMinimized())
+        self.assertTrue(window.isVisible())
+        self.assertFalse(window.isHidden())
+        self.assertEqual(window.windowState(), Qt.WindowNoState)
+
+        window.close()
+
+
 class TestBaseWindowStatusBar(QtTestCase):
     def test_StatusBarInfo(self):
         window = BaseWindow(ui_file)

--- a/tests/test_base_window.py
+++ b/tests/test_base_window.py
@@ -62,7 +62,7 @@ class TestBaseWindowShortcuts(QtTestCase):
 class TestBaseWindowWindowStates(QtTestCase):
     """This test makes sure the window shows up again after being minimized"""
     def test_minimize(self):
-        window = BaseWindow()
+        window = BaseWindow(ui_file)
         self.assertTrue(window.isHidden())
 
         window.ShowOnTop()

--- a/tests/test_plugin_controller.py
+++ b/tests/test_plugin_controller.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 # plugin imports
 from kratos_salome_plugin.gui.plugin_controller import PluginController
+import kratos_salome_plugin.gui.active_window as active_window
 
 # tests imports
 from testing_utilities import QtTestCase, CreateHDFStudyFile, DeleteDirectoryIfExisting, SalomeTestCaseWithBox, skipUnlessPythonVersionIsAtLeast
@@ -115,7 +116,7 @@ class TestPluginControllerGUIConnection(QtTestCase):
             self.assertEqual(patch_fct.open.call_count, 1)
 
 
-class TestPluginControllerWindowCloseReopen(QtTestCase):
+class TestPluginControllerMainWindowCloseReopen(QtTestCase):
     """This test makes sure if the MainWindow is closed, it is not destroyed"""
 
     def test_main_window_reopen(self):
@@ -125,9 +126,19 @@ class TestPluginControllerWindowCloseReopen(QtTestCase):
 
         controller._main_window.close()
 
-        controller.ShowMainWindow()
+        controller._main_window.ShowOnTop()
 
         self.assertIs(orig_obj, controller._main_window)
+
+
+class TestPluginControllerMainWindow_ActiveWindow(QtTestCase):
+    def test_main_window_active_window(self):
+        # setting initial state
+        active_window.ACTIVE_WINDOW = None
+
+        controller = PluginController()
+
+        self.assertIs(active_window.ACTIVE_WINDOW, controller._main_window)
 
 
 # using a module local patch due to import of QFileDialog in project_path_handler
@@ -155,7 +166,7 @@ class TestPluginControllerProject(QtTestCase):
 
     def test_Close(self):
         controller = PluginController()
-        controller.ShowMainWindow()
+        controller._main_window.ShowOnTop()
 
         self.assertFalse(controller._main_window.isMinimized())
         self.assertTrue(controller._main_window.isVisible())

--- a/tests/test_plugin_main_window.py
+++ b/tests/test_plugin_main_window.py
@@ -117,5 +117,17 @@ class TestPluginMainWindowShortcuts(QtTestCase):
             self.assertFalse(self.mocks[mock_name].called, msg='Unexpected call for mock "{}": "{}"'.format(called_mock, mock_name))
 
 
+class TestPluginMainWindow_ActiveWindow(QtTestCase):
+    def test_set_active_window(self):
+        active_window.ACTIVE_WINDOW = None
+
+        window = PluginMainWindow()
+        window.show()
+        window.close()
+
+        # make sure the main win is saved as active when closing it so that it can be reopened
+        self.assertIs(active_window.ACTIVE_WINDOW, window)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_plugin_main_window.py
+++ b/tests/test_plugin_main_window.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 # plugin imports
 from kratos_salome_plugin.gui.plugin_main_window import PluginMainWindow
+import kratos_salome_plugin.gui.active_window as active_window
 
 # tests imports
 from testing_utilities import QtTestCase

--- a/tests/test_plugin_main_window.py
+++ b/tests/test_plugin_main_window.py
@@ -117,32 +117,5 @@ class TestPluginMainWindowShortcuts(QtTestCase):
             self.assertFalse(self.mocks[mock_name].called, msg='Unexpected call for mock "{}": "{}"'.format(called_mock, mock_name))
 
 
-class TestPluginMainWindowWindowStates(QtTestCase):
-    """This test makes sure the window shows up again after being minimized"""
-    def test_minimize(self):
-        main_window = PluginMainWindow()
-        self.assertTrue(main_window.isHidden())
-
-        main_window.ShowOnTop()
-
-        main_window.setWindowState(Qt.WindowMinimized)
-
-        self.assertFalse(main_window.isActiveWindow())
-        self.assertTrue(main_window.isMinimized())
-        self.assertTrue(main_window.isVisible())
-        self.assertFalse(main_window.isHidden())
-        self.assertEqual(main_window.windowState(), Qt.WindowMinimized)
-
-        main_window.ShowOnTop()
-
-        # self.assertTrue(main_window.isActiveWindow()) # commented as doesn't work in the CI and in Linux, seems OS dependent
-        self.assertFalse(main_window.isMinimized())
-        self.assertTrue(main_window.isVisible())
-        self.assertFalse(main_window.isHidden())
-        self.assertEqual(main_window.windowState(), Qt.WindowNoState)
-
-        main_window.close()
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_salome_plugins.py
+++ b/tests/test_salome_plugins.py
@@ -36,9 +36,11 @@ class TestSalomePlugins(QtTestCase):
 
     @patch('PyQt5.QtWidgets.QMessageBox')
     @patch('kratos_salome_plugin.salome_utilities.GetVersions', return_value= [9,4,0])
+    @patch('kratos_salome_plugin.gui.active_window')
     @patch('kratos_salome_plugin.gui.plugin_controller.PluginController')
     def test_CreatePluginController(self,
         mock_plugin_controller,
+        mock_active_window,
         mock_fct_get_versions,
         mock_message_box):
         """Test for checking if the initialization of the PluginController works correctly
@@ -74,13 +76,14 @@ class TestSalomePlugins(QtTestCase):
 
     @patch('PyQt5.QtWidgets.QMessageBox')
     @patch('kratos_salome_plugin.salome_utilities.GetVersions', return_value= [9,3,111])
+    @patch('kratos_salome_plugin.gui.active_window')
     @patch('kratos_salome_plugin.gui.plugin_controller.PluginController')
     def test_IssueUntestedSalomeVersionMsgBox(self,
         mock_plugin_controller,
+        mock_active_window,
         mock_fct_get_versions,
         mock_message_box):
-        """Test for checking if the issuing of the MessageBox for untested Salome versions works
-        """
+        """Test for checking if the issuing of the MessageBox for untested Salome versions works"""
         self.assertEqual(mock_fct_get_versions.call_count, 0)
         self.assertEqual(mock_message_box.warning.call_count, 0)
 
@@ -103,6 +106,32 @@ class TestSalomePlugins(QtTestCase):
 
         self.assertEqual(mock_fct_get_versions.call_count, 2)
         self.assertEqual(mock_message_box.warning.call_count, 1)
+
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    @patch('kratos_salome_plugin.salome_utilities.GetVersions', return_value= [9,3,111])
+    @patch('kratos_salome_plugin.gui.active_window')
+    @patch('kratos_salome_plugin.gui.plugin_controller.PluginController')
+    def test_ShowActiveWindow(self,
+        mock_plugin_controller,
+        mock_active_window,
+        mock_fct_get_versions,
+        mock_message_box):
+        """Test for checking if the active window is shown"""
+        # this does sth when importing, hence doing it inside the test
+        from salome_plugins import InitializePlugin
+
+        self.assertEqual(mock_active_window.ACTIVE_WINDOW.ShowOnTop.call_count, 0)
+
+        salome_context = None # this should not be used hence passing None
+        InitializePlugin(salome_context)
+
+        self.assertEqual(mock_active_window.ACTIVE_WINDOW.ShowOnTop.call_count, 1)
+
+        # calling it a second time is like pressing the plugin button a second time in salome
+        # this should again show the active win on top
+        InitializePlugin(None)
+
+        self.assertEqual(mock_active_window.ACTIVE_WINDOW.ShowOnTop.call_count, 2)
 
 
 def DeleteModuleIfExisting(module_name):

--- a/tui_examples/mok_fsi/salome_model.py
+++ b/tui_examples/mok_fsi/salome_model.py
@@ -211,8 +211,7 @@ is_done_structure = structure_mesh.Compute()
 if not is_done_structure:
     raise Exception("Structure mesh could not be computed!")
 
-# TODO this should be done automatically!
-aCriterion = [smesh.GetCriterion(SMESH.ALL,SMESH.FT_EntityType,'=',SMESH.Entity_Quadrangle)]
+# TODO find a way to do this better => in this specific case Kratos should accept the elements even if their orientation is flipped!
 isDone = structure_mesh.ReorientObject( structure_mesh )
 
 ## Set names of Mesh objects


### PR DESCRIPTION
The currently active window is saved in a global variable
This is necessary in case the window gets minimized
I.e. when the plugin is reopened (with a previously minimized window)
then the last opened window is shown again instead of creating again the base window