### PR TITLE
allow 1N element/conditions creation from 'Node'

### DIFF
--- a/kratos_salome_plugin/mesh_interface.py
+++ b/kratos_salome_plugin/mesh_interface.py
@@ -77,7 +77,7 @@ class MeshInterface:
                 entity_type_str = salome_mesh_utilities.EntityTypeToString(entity_type)
                 if entity_type_str == "Node":
                     logger.debug("Creating 0D elements for all nodes.")
-                    geom_entities["Node"] = {x:[x] for x in nodes.keys()}
+                    geom_entities["Node"] = {x:[x] for x in sorted(nodes.keys())}
                 elif entity_type in entity_types_in_mesh:
                     if salome_mesh_utilities.IsSubMeshProxy(current_mesh):
                         main_mesh = smesh.Mesh(current_mesh.GetFather())

--- a/kratos_salome_plugin/mesh_interface.py
+++ b/kratos_salome_plugin/mesh_interface.py
@@ -61,7 +61,7 @@ class MeshInterface:
         if self.CheckMeshIsValid():
             nodes = self.GetNodes() # nodes are always needed
 
-            geometrical_entity_types_salome = [salome_mesh_utilities.EntityTypeFromString(entity) for entity in geometrical_entity_types if entity != "Node"] # nodes are treated separately
+            geometrical_entity_types_salome = [salome_mesh_utilities.EntityTypeFromString(entity) for entity in geometrical_entity_types]
 
             if len(geometrical_entity_types_salome) == 0:
                 return nodes, {}
@@ -75,8 +75,10 @@ class MeshInterface:
             logged_entity_types_in_mesh = False
             for entity_type in geometrical_entity_types_salome:
                 entity_type_str = salome_mesh_utilities.EntityTypeToString(entity_type)
-                if entity_type in entity_types_in_mesh:
-
+                if entity_type_str == "Node":
+                    logger.debug("Creating 0D elements for all nodes.")
+                    geom_entities["Node"] = {x:[x] for x in nodes.keys()}
+                elif entity_type in entity_types_in_mesh:
                     if salome_mesh_utilities.IsSubMeshProxy(current_mesh):
                         main_mesh = smesh.Mesh(current_mesh.GetFather())
                         sub_shape = current_mesh.GetSubShape()

--- a/tests/test_mesh_interface.py
+++ b/tests/test_mesh_interface.py
@@ -177,7 +177,7 @@ class TestMeshInterfaceMeshRelatedMethods(testing_utilities.SalomeTestCaseWithBo
             "Triangle" : 480,
             "Edge"     : 48,
             "Tetra"    : 1355,
-            "Node"     : 0,
+            "Node"     : 366,
             "0D"       : 14
         }
         self.__Execute_GetGeomEntities_Test(self.mesh_interface_main_mesh_tetra, entity_types, 366)
@@ -204,7 +204,7 @@ class TestMeshInterfaceMeshRelatedMethods(testing_utilities.SalomeTestCaseWithBo
             "Edge"       : 96,
             "Tetra"      : 0,
             "Hexa"       : 512,
-            "Node"       : 0,
+            "Node"       : 729,
             "Ball"       : 17
         }
         self.__Execute_GetGeomEntities_Test(self.mesh_interface_main_mesh_hexa, entity_types, 729)
@@ -407,9 +407,6 @@ class TestMeshInterfaceMeshRelatedMethods(testing_utilities.SalomeTestCaseWithBo
 
         self.assertEqual(num_nodes, len(nodes)) # this might fail if different versions of salome give different meshes
 
-        if "Node" in exp_entity_types:
-            exp_entity_types.pop("Node") # nodes are retrieved separately
-
         self.assertEqual(len(exp_entity_types), len(geom_entities))
 
         num_nodes_per_entity = {
@@ -419,6 +416,7 @@ class TestMeshInterfaceMeshRelatedMethods(testing_utilities.SalomeTestCaseWithBo
             "Ball"       : 1,
             "Hexa"       : 8,
             "0D"         : 1,
+            "Node"       : 1,
             "Tetra"      : 4
         }
 


### PR DESCRIPTION
This allows to create `3D1N` elements/conditions using the `Node`s of Salome.
This allows a more streamlined creation of mdpas, since no 0D elements have to be manually created (in the GUI) after the meshing.

```python
    loads = { "conditions" : {"Node" : {"PointLoadCondition3D1N" : 0} } }
```
will create a `PointLoadCondition3D1N `for every `Node` in the mesh.